### PR TITLE
Patch for Inefficient GPU usage of GradInversion

### DIFF
--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -302,9 +302,8 @@ class GradientInversion_Attack(BaseAttacker):
                 group_fake_x,
                 received_gradients,
             )
-            distance_item = distance.item()
             distance.backward(retain_graph=False)
-            return distance_item
+            return distance
 
         return closure
 

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -302,7 +302,7 @@ class GradientInversion_Attack(BaseAttacker):
                 group_fake_x,
                 received_gradients,
             )
-            distance.backward(retain_graph=False)
+            distance.backward(retain_graph=True)
             return distance
 
         return closure

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -303,6 +303,8 @@ class GradientInversion_Attack(BaseAttacker):
                 received_gradients,
             )
             distance.backward(retain_graph=True)
+            del fake_pred
+            del fake_gradients
             return distance
 
         return closure

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -305,10 +305,6 @@ class GradientInversion_Attack(BaseAttacker):
             distance_val = distance.item()
             distance.backward(retain_graph=False)
 
-            del fake_pred
-            del fake_gradients
-            torch.cuda.empty_cache()
-
             return distance_val
 
         return closure

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -279,6 +279,7 @@ class GradientInversion_Attack(BaseAttacker):
         """
 
         def closure():
+            optimizer.zero_grad()
             if self.custom_generate_fake_grad_fn is None:
                 fake_pred, fake_gradients = _generate_fake_gradients(
                     self.target_model,
@@ -291,7 +292,6 @@ class GradientInversion_Attack(BaseAttacker):
                 fake_pred, fake_gradients = self.custom_generate_fake_grad_fn(
                     self, fake_x, fake_label
                 )
-            optimizer.zero_grad()
             distance = self.distancefunc(
                 fake_gradients, received_gradients, self.gradient_ignore_pos
             )
@@ -303,7 +303,7 @@ class GradientInversion_Attack(BaseAttacker):
                 received_gradients,
             )
             distance_val = distance.item()
-            distance.backward(retain_graph=True)
+            distance.backward(retain_graph=False)
 
             del fake_pred
             del fake_gradients

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -302,9 +302,9 @@ class GradientInversion_Attack(BaseAttacker):
                 group_fake_x,
                 received_gradients,
             )
-
+            distance_item = distance.item()
             distance.backward(retain_graph=False)
-            return distance
+            return distance_item
 
         return closure
 

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -302,7 +302,7 @@ class GradientInversion_Attack(BaseAttacker):
                 group_fake_x,
                 received_gradients,
             )
-            distance_item = distance.item().clone()
+            distance_item = distance.item()
             distance.backward(retain_graph=False)
             return distance_item
 
@@ -374,8 +374,8 @@ class GradientInversion_Attack(BaseAttacker):
                 with torch.no_grad():
                     fake_x[:] = fake_x.clamp(self.clamp_range[0], self.clamp_range[1])
 
-            if torch.sum(torch.isnan(distance)).item():
-                raise OverflowError("stop because the culculated distance is Nan")
+            # if torch.sum(torch.isnan(distance)).item():
+            #    raise OverflowError("stop because the culculated distance is Nan")
 
             if best_distance > distance:
                 best_fake_x = copy.deepcopy(fake_x)

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -303,7 +303,7 @@ class GradientInversion_Attack(BaseAttacker):
                 received_gradients,
             )
 
-            distance.backward(retain_graph=True)
+            distance.backward(retain_graph=False)
             return distance
 
         return closure

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -302,7 +302,7 @@ class GradientInversion_Attack(BaseAttacker):
                 group_fake_x,
                 received_gradients,
             )
-            distance_item = distance.item()
+            distance_item = distance.item().clone()
             distance.backward(retain_graph=False)
             return distance_item
 

--- a/src/aijack/attack/inversion/gradientinversion.py
+++ b/src/aijack/attack/inversion/gradientinversion.py
@@ -435,8 +435,8 @@ class GradientInversion_Attack(BaseAttacker):
             group_optimizer.append(optimizer)
 
         best_distance = [float("inf") for _ in range(self.group_num)]
-        best_fake_x = group_fake_x.detach().clone()
-        best_fake_label = group_fake_label.detach().clone()
+        best_fake_x = [x_.detach().clone() for x_ in group_fake_x]
+        best_fake_label = [y_.detach().clone() for y_ in group_fake_label]
         best_iteration = [0 for _ in range(self.group_num)]
 
         self.log_loss = [[] for _ in range(self.group_num)]

--- a/src/aijack/attack/inversion/utils/utils.py
+++ b/src/aijack/attack/inversion/utils/utils.py
@@ -118,7 +118,8 @@ def _generate_fake_gradients(
     fake_gradients = torch.autograd.grad(
         loss,
         target_model.parameters(),
-        create_graph=True,
+        create_graph=False,
         allow_unused=True,
     )
+    fake_gradients = [g.requires_grad_(True) for g in fake_gradients]
     return fake_pred, fake_gradients

--- a/src/aijack/attack/inversion/utils/utils.py
+++ b/src/aijack/attack/inversion/utils/utils.py
@@ -118,8 +118,7 @@ def _generate_fake_gradients(
     fake_gradients = torch.autograd.grad(
         loss,
         target_model.parameters(),
-        create_graph=False,
+        create_graph=True,
         allow_unused=True,
     )
-    fake_gradients = [g.requires_grad_(True) for g in fake_gradients]
     return fake_pred, fake_gradients


### PR DESCRIPTION
Close #133 

- avoid using `retain_graph=True`.
- save the intermediate result on CPU, not on GPU

Co-authored-by: lokeshn011101 <lokesh19055@cse.ssn.edu.in>
Co-authored-by: iamyifan <jeffluoyifan@gmail.com>