### PR TITLE
Fix #180 : Unused variable 'i'

### DIFF
--- a/src/aijack/attack/labelleakage/normattack.py
+++ b/src/aijack/attack/labelleakage/normattack.py
@@ -42,7 +42,7 @@ def attach_normattack_to_splitnn(
             """
             epoch_labels = []
             epoch_g_norm = []
-            for i, data in enumerate(dataloader, 0):
+            for data in dataloader:
                 inputs, labels = data
                 inputs = inputs.to(self.device)
                 labels = labels.to(self.device)


### PR DESCRIPTION
Hello,
Hope you're doing well.
As per the requirement mentioned in issue #180, I have removed the **"enumerate"** function which would generate the indices, thereby removing the **"i"** variable too.
If at all I misunderstood something or made any mistakes, then I am sincerely sorry for the same.
Do let me know if there's anything else that is needed from my end.

Thanks and Regards,
Mohit Kambli